### PR TITLE
Add a sourceMap config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ export default [{
   entry: 'src/child-folder/bar.js',
   dest: 'dist/bar.js',
   format: 'umd',
-  moduleName: 'bar'
+  moduleName: 'bar',
+  sourceMap: 'inline'
 }]
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,8 @@ function buildBundle (config) {
       return bundle.write({
         format: config.format || 'es6',
         dest: config.dest,
-        moduleName: config.moduleName
+        moduleName: config.moduleName,
+        sourceMap: config.sourceMap
       }).then(() => config.dest)
     })
 }


### PR DESCRIPTION
I just spent a very confused morning wondering why rollem didn't generate my source maps - turns out the `sourceMap` option isn't passed through. This PR adds that option and adds it to the README.

I think rollem might need the other bundle generation flags, too - but for now, `sourceMap` is the only one I need (:
