### PR TITLE
Add support for bundle.globals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ function buildBundle (config) {
       return bundle.write({
         format: config.format || 'es6',
         dest: config.dest,
+        globals: config.globals,
         moduleName: config.moduleName,
         sourceMap: config.sourceMap
       }).then(() => config.dest)


### PR DESCRIPTION
This adds support for passing globals to the Rollup bundle config.

Tested it locally. Let me know if you want me to update the tests.