### PR TITLE
fix(config): do not use deprecated format option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ function buildBundle (config) {
   return rollup.rollup(config)
     .then(function (bundle) {
       return bundle.write({
-        format: config.format || 'es6',
+        format: config.format || 'es',
         dest: config.dest,
         globals: config.globals,
         moduleName: config.moduleName,


### PR DESCRIPTION
Since https://github.com/rollup/rollup/issues/468 the `es6` option is deprecated.
New option name is just `es`.